### PR TITLE
📝 Add the RFC documentation

### DIFF
--- a/doc/RFC_Jetpack.txt
+++ b/doc/RFC_Jetpack.txt
@@ -1,0 +1,74 @@
+                          EPITECH Jetpack Protocol
+
+
+0. Introduction
+
+    This documentation officializes the protocol of the Jetpack project to
+    communicate between the server and the client.
+
+    It defines a list of commands and possible values of these commands, but also
+    some rules related to the physics of the program.
+
+    Communications are made in TCP, by sending the commands in text and not
+    encoded.
+
+    For example: "FIRE 0" where the name of the command is in uppercase and
+    the content is split by spaces (in this documentation denoted by <SP>).
+
+    All commands must end with the Telnet end-of-line code <CRLF>.
+
+1. Formats
+
+    1.1 Map
+
+        The map, given as a parameter to the server, must use:
+            - "_" -> empty space
+            - "e" -> electric fence (obstacle)
+            - "c" -> coin
+
+    1.2 Gravity
+
+        To follow the server simulation, the client must use the following
+        math formulas for gravity:
+
+        > position_y = position_y - (velocity_y * deltatime)
+        > velocity_y = velocity_y - (gravity * deltatime)
+
+        (The velocity of X is constant and is given by the server)
+        The gravity is given by the server in the HELLO command, and is a
+        constant value.
+
+2. Commands
+
+    Arguments are surrounded by <> (special cases are <SP> (space) and <CRLF>
+    (end of command))
+
+    2.1 Server side
+
+        START <CRLF> ->
+            server is ready to start the game
+
+        MAP <map> <length> <height> <repetition> <CRLF> ->
+            send the map to the client (with the length, height and repetition)
+
+        HELLO <playerNumber> <gravity> <velocity_x> <CRLF> ->
+            send the ID of the player to the client
+
+        PLAYER <playerNumber> <x> <y> <velocity_y> <coins> <isFiring> <CRLF> ->
+            send the state of the game for the given player
+
+        DEATH <playerNumber> <CRLF> ->
+            send the ID of the player who died
+
+        FINISH <playerNumber> <CRLF> ->
+            send the ID of the player who won
+
+    2.2 Client side
+
+        READY <CRLF> ->
+            client is ready to start the game (the server must wait for all
+            players)
+
+        FIRE <isFiring> <CRLF> ->
+            send info if the player is firing (moving up). !! Value must be 0
+            (not firing) or 1 (firing) !!

--- a/doc/RFC_Jetpack.txt
+++ b/doc/RFC_Jetpack.txt
@@ -1,5 +1,16 @@
                           EPITECH Jetpack Protocol
 
+RFC Number: EPITECH-RFC-023
+Category: Standards Track
+Subcategory: Protocol
+Title: Jetpack Protocol
+Status: Active
+Version: 1.0
+Date: April 2, 2025
+Authors:
+    - Léopold PINTARD
+    - Carlos SO BUARO
+    - Arthuryan LOHEAC DE SAINTE MARIE
 
 0. Introduction
 


### PR DESCRIPTION
This pull request introduces the official documentation for the EPITECH Jetpack Protocol, outlining the communication protocol between the server and the client. The documentation includes a detailed description of commands, formats, and rules related to the physics of the game.

Key changes include:

* Addition of the introduction section explaining the purpose and structure of the protocol.
* Definition of map formats and gravity calculations to be used by the client.
* Detailed list of server-side commands such as `START`, `MAP`, `HELLO`, `PLAYER`, `DEATH`, and `FINISH`, including their arguments and expected behavior.
* Detailed list of client-side commands such as `READY` and `FIRE`, including their arguments and expected behavior.

closes #31 