### PR TITLE
:sparkles: simuler gravité et position en local

### DIFF
--- a/include/clientRun/ClientRun.hpp
+++ b/include/clientRun/ClientRun.hpp
@@ -42,3 +42,4 @@ int graphic(void);
 void update(Game &game, Window &window);
 void handleCommand(std::string command);
 void updateImagePlayer(Player &player);
+void handleMaxMin(sf::Vector2f &position);

--- a/main_client.cpp
+++ b/main_client.cpp
@@ -35,8 +35,8 @@ int main(int ac, char **av) {
     DataManager dataManager;
     DataManager::instance->setDebug(false);
     Client client(0, sockfd, "");
-    Player player(DataManager::instance->getTexturePlayer());
-    DataManager::instance->getPlayers().push_back(player);
+    DataManager::instance->getPlayers().push_back(
+        std::make_unique<Player>(DataManager::instance->getTexturePlayer()));
 
     if (!(ac == 5 || ac == 6))
         return 84;

--- a/src/client/client/CommandHandling.cpp
+++ b/src/client/client/CommandHandling.cpp
@@ -53,22 +53,20 @@ static void handlePlayer(std::istringstream& iss) {
 
     if (!isIdInList(id)) {
         Player &newPlayer = DataManager::instance->addNewPlayer();
-        newPlayer.getMutexPlayer().lock();
+        std::lock_guard<std::mutex> lock(newPlayer.getMutexPlayer());
         newPlayer.setId(id);
         newPlayer.setPos(x, y);
         newPlayer.setVelocityY(velocityY);
         newPlayer.setFire(isFire);
         newPlayer.setCoins(coins);
-        newPlayer.getMutexPlayer().unlock();
     } else {
         for (const auto &p : DataManager::instance->getPlayers()) {
             if (p->getId() == id) {
-                p->getMutexPlayer().lock();
+                std::lock_guard<std::mutex> lock(p->getMutexPlayer());
                 p->setPos(x, y);
                 p->setVelocityY(velocityY);
                 p->setFire(isFire);
                 p->setCoins(coins);
-                p->getMutexPlayer().unlock();
             }
         }
     }

--- a/src/client/client/CommandHandling.cpp
+++ b/src/client/client/CommandHandling.cpp
@@ -27,8 +27,8 @@ static void handleHello(std::istringstream& iss) {
 }
 
 static bool isIdInList(int id) {
-    for (auto &p : DataManager::instance->getPlayers()) {
-        if (p.getId() == id)
+    for (const auto &p : DataManager::instance->getPlayers()) {
+        if (p->getId() == id)
             return true;
     }
     return false;
@@ -53,18 +53,22 @@ static void handlePlayer(std::istringstream& iss) {
 
     if (!isIdInList(id)) {
         Player &newPlayer = DataManager::instance->addNewPlayer();
+        newPlayer.getMutexPlayer().lock();
         newPlayer.setId(id);
         newPlayer.setPos(x, y);
         newPlayer.setVelocityY(velocityY);
         newPlayer.setFire(isFire);
         newPlayer.setCoins(coins);
+        newPlayer.getMutexPlayer().unlock();
     } else {
-        for (auto &p : DataManager::instance->getPlayers()) {
-            if (p.getId() == id) {
-                p.setPos(x, y);
-                p.setVelocityY(velocityY);
-                p.setFire(isFire);
-                p.setCoins(coins);
+        for (const auto &p : DataManager::instance->getPlayers()) {
+            if (p->getId() == id) {
+                p->getMutexPlayer().lock();
+                p->setPos(x, y);
+                p->setVelocityY(velocityY);
+                p->setFire(isFire);
+                p->setCoins(coins);
+                p->getMutexPlayer().unlock();
             }
         }
     }

--- a/src/client/client/DataManager.cpp
+++ b/src/client/client/DataManager.cpp
@@ -42,14 +42,15 @@ std::string DataManager::getIp() const {
     return ip;
 }
 
-std::vector<Player> &DataManager::getPlayers() {
+std::vector<std::unique_ptr<Player>> &DataManager::getPlayers() {
     return players;
 }
 
 Player &DataManager::addNewPlayer() {
-    players.emplace_back(DataManager::instance->getTexturePlayer());
-    return players.back();
+    players.emplace_back(std::make_unique<Player>(texturePlayer));
+    return *players.back();
 }
+
 void DataManager::setGravity(int gravity) {
     this->gravity = gravity;
 }

--- a/src/client/client/DataManager.hpp
+++ b/src/client/client/DataManager.hpp
@@ -15,7 +15,7 @@ class DataManager {
 
     int port;
     std::string ip;
-    std::vector<Player> players;
+    std::vector<std::unique_ptr<Player>> players;
     sf::Texture texturePlayer;
     sf::Texture textureBackground;
 
@@ -30,7 +30,7 @@ class DataManager {
     bool getDebug() const;
     int getPort() const;
     std::string getIp() const;
-    std::vector<Player> &getPlayers();
+    std::vector<std::unique_ptr<Player>> &getPlayers();
     Player &addNewPlayer();
 
     void setGravity(int gravity);

--- a/src/client/graphic/GraphicalClient.cpp
+++ b/src/client/graphic/GraphicalClient.cpp
@@ -54,7 +54,7 @@ void updateVelocity(float deltaTime, Player &player) {
 
 void updatePlayers(Window &window) {
     for (auto &player : DataManager::instance->getPlayers()) {
-        player->getMutexPlayer().lock();
+        std::lock_guard<std::mutex> lock(player->getMutexPlayer());
         if (player->getId() != Player::instance->getId()) {
             sf::Vector2f position =
                 {player->getX(), player->getY()};
@@ -63,7 +63,6 @@ void updatePlayers(Window &window) {
             handleMaxMin(position);
             player->setPos(position.x, position.y);
         }
-        player->getMutexPlayer().unlock();
     }
 }
 

--- a/src/client/graphic/GraphicalClient.cpp
+++ b/src/client/graphic/GraphicalClient.cpp
@@ -52,32 +52,17 @@ void updateVelocity(float deltaTime, Player &player) {
         ((-gravite + fireVelocity) * deltaTime));
 }
 
-void updateVelocityP1(std::map<int, int> &map_keys, float deltaTime, Player &player) {
-    float fireVelocity = 0;
-    float gravite = DataManager::instance->getGravity();
-
-    if (map_keys[sf::Keyboard::Z] == sf::Event::KeyPressed ||
-        map_keys[sf::Keyboard::Space] == sf::Event::KeyPressed) {
-        player.setLanding(Player::ON_AIR);
-        fireVelocity = DataManager::instance->getSpeedJetpack();
-    }
-    player.setFire(fireVelocity != 0);
-    player.setVelocityY(player.getVelocityY() +
-        ((-gravite + fireVelocity) * deltaTime));
-}
-
 void updatePlayers(Window &window) {
     for (auto &player : DataManager::instance->getPlayers()) {
         player->getMutexPlayer().lock();
-        sf::Vector2f position =
-            {player->getX(), player->getY()};
-        if (player->getId() == Player::instance->getId())
-            updateVelocityP1(window.getMapKeys(), window.getDeltaTime(), *player);
-        else 
+        if (player->getId() != Player::instance->getId()) {
+            sf::Vector2f position =
+                {player->getX(), player->getY()};
             updateVelocity(window.getDeltaTime(), *player);
-        position.y -= (player->getVelocityY() * window.getDeltaTime());
-        handleMaxMin(position);
-        player->setPos(position.x, position.y);
+            position.y -= (player->getVelocityY() * window.getDeltaTime());
+            handleMaxMin(position);
+            player->setPos(position.x, position.y);
+        }
         player->getMutexPlayer().unlock();
     }
 }

--- a/src/client/graphic/GraphicalClient.cpp
+++ b/src/client/graphic/GraphicalClient.cpp
@@ -26,18 +26,18 @@ static void Event(Window &window) {
 void drawPlayers(Window &window) {
     // Draw the players
     for (auto &player : DataManager::instance->getPlayers()) {
-        if (player.getId() != Player::instance->getId()) {
-            updateImagePlayer(player);
-            player.getImage().setPosition(player.getX(), player.getY());
-            player.getImage().setTransparency(100);
-            player.getImage().draw(window.getWindow());
+        if (player->getId() != Player::instance->getId()) {
+            updateImagePlayer(*player);
+            player->getImage().setPosition(player->getX(), player->getY());
+            player->getImage().setTransparency(100);
+            player->getImage().draw(window.getWindow());
         }
     }
     // Draw the main player in front
     for (auto &player : DataManager::instance->getPlayers()) {
-        if (player.getId() == Player::instance->getId()) {
+        if (player->getId() == Player::instance->getId()) {
             Player::instance->getImage().setPosition(
-                player.getX(), player.getY());
+                player->getX(), player->getY());
             Player::instance->getImage().draw(window.getWindow());
         }
     }

--- a/src/client/graphic/Player.hpp
+++ b/src/client/graphic/Player.hpp
@@ -1,11 +1,6 @@
-/*
-** EPITECH PROJECT, 2025
-** Jetpack
-** File description:
-** Player
-*/
-
 #pragma once
+#include <mutex>
+
 #include "client/graphic/ImageClass.hpp"
 
 class Player {
@@ -44,6 +39,7 @@ class Player {
     int getId() { return id; }
     void setCoins(int coins) { this->coins = coins; }
     int getCoins() { return coins; }
+    std::mutex &getMutexPlayer() { return mutexPlayer; }
 
  private:
     float x = 100;
@@ -57,4 +53,5 @@ class Player {
     int id = 0;
     ImageClass img;
     Landing landing = ON_AIR;
+    std::mutex mutexPlayer;
 };

--- a/src/client/graphic/Update.cpp
+++ b/src/client/graphic/Update.cpp
@@ -123,6 +123,7 @@ void update(Game &game, Window &window) {
     sf::Vector2f position =
         {Player::instance->getX(), Player::instance->getY()};
 
+    Player::instance->getMutexPlayer().lock();
     updateVelocity(window.getMapKeys(), window.getDeltaTime());
     position.y -= (Player::instance->getVelocityY() * window.getDeltaTime());
     handleMaxMin(position);
@@ -131,4 +132,5 @@ void update(Game &game, Window &window) {
     Player::instance->getImage().updateAnimation();
     updateImage();
     updateSound(game, window);
+    Player::instance->getMutexPlayer().unlock();
 }

--- a/src/client/graphic/Update.cpp
+++ b/src/client/graphic/Update.cpp
@@ -13,7 +13,7 @@
 #include "client/graphic/game/Game.hpp"
 #include "client/graphic/window/Window.hpp"
 
-static void handleMaxMin(sf::Vector2f &position) {
+void handleMaxMin(sf::Vector2f &position) {
     bool isGround = false;
     if (position.y >= HEIGHT - Player::instance->getHeight() - 30) {
         position.y = HEIGHT - Player::instance->getHeight() - 30;

--- a/src/client/graphic/Update.cpp
+++ b/src/client/graphic/Update.cpp
@@ -123,7 +123,7 @@ void update(Game &game, Window &window) {
     sf::Vector2f position =
         {Player::instance->getX(), Player::instance->getY()};
 
-    Player::instance->getMutexPlayer().lock();
+    std::lock_guard<std::mutex> lock(Player::instance->getMutexPlayer());
     updateVelocity(window.getMapKeys(), window.getDeltaTime());
     position.y -= (Player::instance->getVelocityY() * window.getDeltaTime());
     handleMaxMin(position);
@@ -132,5 +132,4 @@ void update(Game &game, Window &window) {
     Player::instance->getImage().updateAnimation();
     updateImage();
     updateSound(game, window);
-    Player::instance->getMutexPlayer().unlock();
 }


### PR DESCRIPTION
Adding mutexes to the `Player` class and update them locally for bad connections 

### Player object management:

* `src/client/client/DataManager.hpp`, `src/client/client/DataManager.cpp`: Changed the `players` vector to store `unique_ptr<Player>` instead of `Player` objects. Updated methods to work with `unique_ptr<Player>`.

### Thread safety:

* [`src/client/graphic/Player.hpp`](diffhunk://#diff-3c6f3c1e7a0797db8ad9319b8d78a4f0d4797457b7fde03572c8f99747272110L1-R3): Added a `mutex` member to the `Player` class and provided a getter method for it.
* [`src/client/client/CommandHandling.cpp`](diffhunk://#diff-b2c6bdb89e39f2412c337f188fa3ffa6323455f0c3c5ccc2d5b2f3727df44487R56-R71): Locked and unlocked the player mutex when modifying player properties in `handlePlayer`.
* [`src/client/graphic/GraphicalClient.cpp`](diffhunk://#diff-e248ac94177882926d05b688378f5698e8ab4a1f6573bcab2a5f1d7613fe3dedL29-R69): Added `updatePlayers` function to update player positions while locking and unlocking the player mutex. 

### Minor updates:

* [`include/clientRun/ClientRun.hpp`](diffhunk://#diff-9c13e98470a93bf57afd0fb28ff9830bae528b10aa1cf7f6a4e4263960f72f87R45): Added `handleMaxMin` function declaration.
* [`main_client.cpp`](diffhunk://#diff-4bd3009dfa38f67aadbf8b6b31c7a4f1b4cf60ccd3a775e6093599ffc7c0d4bbL38-R39): Updated player creation to use `unique_ptr`.
* [`src/client/graphic/Update.cpp`](diffhunk://#diff-3acd97d4d2726e87087ddaaae8d46b8f9d36c30d65edff1e19fae9bccefbb020L16-R16): Made `handleMaxMin` function non-static and added mutex locking/unlocking in the `update` function.