### PR TITLE
:sparkles: Implement handleDeath command and update Player class for alive status management

### DIFF
--- a/src/client/client/CommandHandling.cpp
+++ b/src/client/client/CommandHandling.cpp
@@ -98,6 +98,21 @@ static void handleReady(std::istringstream& iss) {
     }
 }
 
+static void handleDeath(std::istringstream& iss) {
+    std::string idStr;
+    std::getline(iss, idStr, ' ');
+
+    int id = std::stoi(idStr);
+
+    for (const auto &p : DataManager::instance->getPlayers()) {
+        if (p->getId() == id) {
+            std::lock_guard<std::mutex> lock(p->getMutexPlayer());
+            p->setAlive(false);
+            break;
+        }
+    }
+}
+
 void handleStart() {
     DataManager::instance->mutexState.lock();
     DataManager::instance->setState(DataManager::GAME);
@@ -129,4 +144,6 @@ void handleCommand(std::string command) {
         handleReady(iss);
     else if (commandName == "MAP")
         handleMap(iss);
+    else if (commandName == "DEATH")
+        handleDeath(iss);
 }

--- a/src/client/graphic/Player.hpp
+++ b/src/client/graphic/Player.hpp
@@ -45,6 +45,8 @@ class Player {
     int getId() { return id; }
     void setCoins(int coins) { this->coins = coins; }
     int getCoins() { return coins; }
+    void setAlive(bool isAlive) { this->isAlive = isAlive; }
+    bool getAlive() { return isAlive; }
     std::mutex &getMutexPlayer() { return mutexPlayer; }
     Ready getReady() {
         std::lock_guard<std::mutex> lock(mutexPlayer);
@@ -65,6 +67,7 @@ class Player {
     bool isGround = false;
     int coins = 0;
     int id = 0;
+    bool isAlive = true;
     Ready ready = NOT_READY;
     ImageClass img;
     Landing landing = ON_AIR;

--- a/src/server/server/ServerGame.cpp
+++ b/src/server/server/ServerGame.cpp
@@ -4,7 +4,7 @@
 #include "game/gameConstants.hpp"
 #include "server/Obstacle.hpp"
 
-#include "SFML/Graphics.h"
+#include "SFML/Graphics.hpp"
 
 void Server::startGame() {
     gameStarted = true;


### PR DESCRIPTION
This pull request introduces a new feature to handle player death events in the game. The changes include adding a new method to manage the death state of players and updating the command handling logic to incorporate this new functionality.

New feature to handle player death events:

* [`src/client/client/CommandHandling.cpp`](diffhunk://#diff-b2c6bdb89e39f2412c337f188fa3ffa6323455f0c3c5ccc2d5b2f3727df44487R101-R115): Added the `handleDeath` function to update the player's alive status when a death event is received. Integrated this function into the `handleCommand` method to handle the "DEATH" command. [[1]](diffhunk://#diff-b2c6bdb89e39f2412c337f188fa3ffa6323455f0c3c5ccc2d5b2f3727df44487R101-R115) [[2]](diffhunk://#diff-b2c6bdb89e39f2412c337f188fa3ffa6323455f0c3c5ccc2d5b2f3727df44487R147-R148)
* [`src/client/graphic/Player.hpp`](diffhunk://#diff-3c6f3c1e7a0797db8ad9319b8d78a4f0d4797457b7fde03572c8f99747272110R48-R49): Added `setAlive` and `getAlive` methods to the `Player` class to manage the player's alive status. Introduced a new boolean member `isAlive` to track whether the player is alive. [[1]](diffhunk://#diff-3c6f3c1e7a0797db8ad9319b8d78a4f0d4797457b7fde03572c8f99747272110R48-R49) [[2]](diffhunk://#diff-3c6f3c1e7a0797db8ad9319b8d78a4f0d4797457b7fde03572c8f99747272110R70)