### PR TITLE
🐛 Fix bug when the first player quit the game in the menu

### DIFF
--- a/src/server/server/ServerMenu.cpp
+++ b/src/server/server/ServerMenu.cpp
@@ -1,11 +1,17 @@
 #include "server/server/Server.hpp"
 #include "game/gameConstants.hpp"
+#include "log/Log.hpp"
 
 void Server::sendReadyDataToEachClient(ClientServer &player) {
     for (auto &otherClient : clients) {
-        player.sendOutput("READY " +
-            std::to_string(otherClient.second.getPlayer().id) + " " +
-            std::to_string(otherClient.second.ready));
+        try {
+            player.sendOutput("READY " +
+                std::to_string(otherClient.second.getPlayer().id) + " " +
+                std::to_string(otherClient.second.ready));
+        } catch (const std::exception &e) {
+            Log::error() << "Error sending ready data to client: "
+                << e.what() << std::endl;
+        }
     }
 }
 


### PR DESCRIPTION
closes #65 
This pull request includes a significant update to the error handling mechanism in the `ServerMenu` component. The most important change is the addition of logging to capture exceptions when sending ready data to clients.

Error handling improvements:

* [`src/server/server/ServerMenu.cpp`](diffhunk://#diff-2145c6f8b014deb1f25e4faf60f3f77f0e79ff489d890c8a0451581a3ae727e3R3-R14): Added a try-catch block to handle exceptions when sending ready data to clients and log any errors encountered using the `Log` class.