### PR TITLE
:bug: Faire que les commandes renvoies OK ou KO

### DIFF
--- a/src/server/client/ClientServerIO.cpp
+++ b/src/server/client/ClientServerIO.cpp
@@ -44,8 +44,9 @@ void ClientServer::handleCommand(std::string command) {
     } else if (commandName == "BYE") {
         sendOutput("200 ok");
         throw clientException("Client disconnected");
-    } else
+    } else {
         sendOutput("501 Not implemented");
+    }
 }
 
 bool ClientServer::handleInput() {

--- a/src/server/client/ClientServerIO.cpp
+++ b/src/server/client/ClientServerIO.cpp
@@ -35,12 +35,17 @@ void ClientServer::handleCommand(std::string command) {
     std::string commandName;
 
     std::getline(iss, commandName, ' ');
-    if (commandName == "FIRE")
+    if (commandName == "FIRE") {
+        sendOutput("200 ok");
         handleFire(iss);
-    if (commandName == "READY")
+    } else if (commandName == "READY") {
+        sendOutput("200 ok");
         handleReady(iss);
-    if (commandName == "BYE")
+    } else if (commandName == "BYE") {
+        sendOutput("200 ok");
         throw clientException("Client disconnected");
+    } else
+        sendOutput("501 Not implemented");
 }
 
 bool ClientServer::handleInput() {


### PR DESCRIPTION
…responses for FIRE, READY, and BYE commands
This pull request updates the `handleCommand` method in `ClientServerIO.cpp` to improve client-server communication by adding response messages for command handling and ensuring unrecognized commands are properly addressed.

Improvements to command handling:

* [`src/server/client/ClientServerIO.cpp`](diffhunk://#diff-b9476f4d7e7a42f8374521fabd38f5bd94b32cae3488187a4980dde67be549c7L38-R48): Added a `sendOutput` call to send "200 ok" responses for recognized commands (`FIRE`, `READY`, `BYE`) to acknowledge successful processing.
* [`src/server/client/ClientServerIO.cpp`](diffhunk://#diff-b9476f4d7e7a42f8374521fabd38f5bd94b32cae3488187a4980dde67be549c7L38-R48): Added a fallback `sendOutput` call to send "501 Not implemented" for unrecognized commands, improving error handling and client feedback.